### PR TITLE
[nrf fromlist] net: lwm2m: Resource Instance level read access.

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -2301,6 +2301,12 @@ static int lwm2m_read_handler(struct lwm2m_engine_obj_inst *obj_inst,
 			continue;
 		}
 
+		/* v1.1 allows resource instance level access */
+		if (msg->path.level == 4U &&
+		    msg->path.res_inst_id != res->res_instances[i].res_inst_id) {
+			continue;
+		}
+
 		if (res->res_inst_count > 1) {
 			msg->path.res_inst_id =
 				res->res_instances[i].res_inst_id;

--- a/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_oma_tlv.c
@@ -382,6 +382,13 @@ static int put_end_ri(struct lwm2m_output_context *out,
 		return -EINVAL;
 	}
 
+	/* v1.1 allows resource instance level access
+	 * -> skip writing Multiple Resource TLV if path level is 4
+	 */
+	if (path->level == 4U) {
+		return 0;
+	}
+
 	return put_end_tlv(out, fd->mark_pos_ri, &fd->writer_flags,
 			   WRITER_RESOURCE_INSTANCE,
 			   OMA_TLV_TYPE_MULTI_RESOURCE, path->res_id);

--- a/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
@@ -420,8 +420,10 @@ const struct lwm2m_reader plain_text_reader = {
 int do_read_op_plain_text(struct lwm2m_message *msg, int content_format)
 {
 	/* Plain text can only return single resource */
-	if (msg->path.level != 3U) {
-		return -EPERM; /* NOT_ALLOWED */
+	if (msg->path.level < 3U) {
+		return -EPERM;
+	} else if (msg->path.level > 4U) {
+		return -ENOENT;
 	}
 
 	return lwm2m_perform_read_op(msg, content_format);


### PR DESCRIPTION
Makes possible to read a single resource instance at a time with
plaint text, JSON and TLV content formats.

Signed-off-by: Veijo Pesonen <veijo.pesonen@nordicsemi.no>
(based on PR zephyrproject-rtos/zephyr#42357)