### PR TITLE
net: lwm2m: Observation refactor

### DIFF
--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -544,14 +544,16 @@ struct lwm2m_objlnk {
  * LwM2M clients use this function to modify the pmin attribute
  * for an observation being made.
  * Example to update the pmin of a temperature sensor value being observed:
- * lwm2m_engine_update_observer_min_period("3303/0/5700",5);
+ * lwm2m_engine_update_observer_min_period("client_ctx, 3303/0/5700", 5);
  *
+ * @param[in] client_ctx LwM2M context
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res"
  * @param[in] period_s Value of pmin to be given (in seconds).
  *
  * @return 0 for success or negative in case of error.
  */
-int lwm2m_engine_update_observer_min_period(const char *pathstr, uint32_t period_s);
+int lwm2m_engine_update_observer_min_period(struct lwm2m_ctx *client_ctx, const char *pathstr,
+					    uint32_t period_s);
 
 /**
  * @brief Change an observer's pmax value.
@@ -559,14 +561,16 @@ int lwm2m_engine_update_observer_min_period(const char *pathstr, uint32_t period
  * LwM2M clients use this function to modify the pmax attribute
  * for an observation being made.
  * Example to update the pmax of a temperature sensor value being observed:
- * lwm2m_engine_update_observer_max_period("3303/0/5700",5);
+ * lwm2m_engine_update_observer_max_period("client_ctx, 3303/0/5700", 5);
  *
+ * @param[in] client_ctx LwM2M context
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res"
  * @param[in] period_s Value of pmax to be given (in seconds).
  *
  * @return 0 for success or negative in case of error.
  */
-int lwm2m_engine_update_observer_max_period(const char *pathstr, uint32_t period_s);
+int lwm2m_engine_update_observer_max_period(struct lwm2m_ctx *client_ctx, const char *pathstr,
+					    uint32_t period_s);
 
 /**
  * @brief Create an LwM2M object instance.

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -83,14 +83,14 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 struct observe_node {
 	sys_snode_t node;
 	struct lwm2m_obj_path path;
-	uint8_t  token[MAX_TOKEN_LEN];
-	int64_t event_timestamp;
+	bool resource_update :1; 	/* Resource is updated */
+	uint8_t token[MAX_TOKEN_LEN];	/* Observation Token */
+	int64_t event_timestamp;	/* Timestamp for trig next Notify  */
 	int64_t last_timestamp;
-	uint32_t min_period_sec;
-	uint32_t max_period_sec;
 	uint32_t counter;
 	uint16_t format;
 	uint8_t  tkl;
+
 };
 
 struct notification_attrs {
@@ -364,24 +364,194 @@ static void clear_attrs(void *ref)
 	}
 }
 
+
+static bool lwm2m_observer_path_compare(struct lwm2m_obj_path *o_p, struct lwm2m_obj_path *p)
+{
+	/* updated path is deeper than obs node, skip */
+	if (p->level > o_p->level) {
+		return false;
+	}
+
+	/* check obj id matched or not */
+	if (p->obj_id != o_p->obj_id) {
+		return false;
+	}
+
+	if (o_p->level >= LWM2M_PATH_LEVEL_OBJECT_INST) {
+		if (p->level >= LWM2M_PATH_LEVEL_OBJECT_INST &&
+		    p->obj_inst_id != o_p->obj_inst_id) {
+			return false;
+		}
+	}
+
+	if (o_p->level >= LWM2M_PATH_LEVEL_RESOURCE) {
+		if (p->level >= LWM2M_PATH_LEVEL_RESOURCE &&
+		    p->res_id != o_p->res_id) {
+			return false;
+		}
+	}
+
+	if (IS_ENABLED(CONFIG_LWM2M_VERSION_1_1) &&
+	    o_p->level == LWM2M_PATH_LEVEL_RESOURCE_INST) {
+		if (p->level == LWM2M_PATH_LEVEL_RESOURCE_INST &&
+		    p->res_inst_id != o_p->res_inst_id) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
 int lwm2m_notify_observer(uint16_t obj_id, uint16_t obj_inst_id, uint16_t res_id)
 {
+	struct lwm2m_obj_path path;
+
+	path.level = LWM2M_PATH_LEVEL_RESOURCE;
+	path.obj_id = obj_id;
+	path.obj_inst_id = obj_inst_id;
+	path.res_id = res_id;
+
+	return lwm2m_notify_observer_path(&path);
+}
+
+static int engine_observe_get_attributes(struct lwm2m_obj_path *path,
+					 struct notification_attrs *attrs, uint16_t srv_obj_inst)
+{
+	struct lwm2m_engine_obj *obj;
+	struct lwm2m_engine_obj_field *obj_field = NULL;
+	struct lwm2m_engine_obj_inst *obj_inst = NULL;
+	struct lwm2m_engine_res_inst *res_inst = NULL;
+	int ret, i;
+
+	/* defaults from server object */
+	attrs->pmin = lwm2m_server_get_pmin(srv_obj_inst);
+	attrs->pmax = lwm2m_server_get_pmax(srv_obj_inst);
+	attrs->flags = BIT(LWM2M_ATTR_PMIN) | BIT(LWM2M_ATTR_PMAX);
+
+	/* check if object exists */
+	obj = get_engine_obj(path->obj_id);
+	if (!obj) {
+		LOG_ERR("unable to find obj: %u", path->obj_id);
+		return -ENOENT;
+	}
+
+	ret = update_attrs(obj, attrs);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* check if object instance exists */
+	if (path->level >= LWM2M_PATH_LEVEL_OBJECT_INST) {
+		obj_inst = get_engine_obj_inst(path->obj_id,
+					       path->obj_inst_id);
+		if (!obj_inst) {
+			LOG_ERR("unable to find obj_inst: %u/%u",
+				path->obj_id, path->obj_inst_id);
+			return -ENOENT;
+		}
+
+		ret = update_attrs(obj_inst, attrs);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	/* check if resource exists */
+	if (path->level >= LWM2M_PATH_LEVEL_RESOURCE) {
+		for (i = 0; i < obj_inst->resource_count; i++) {
+			if (obj_inst->resources[i].res_id == path->res_id) {
+				break;
+			}
+		}
+
+		if (i == obj_inst->resource_count) {
+			LOG_ERR("unable to find res_id: %u/%u/%u",
+				path->obj_id, path->obj_inst_id,
+				path->res_id);
+			return -ENOENT;
+		}
+
+		/* load object field data */
+		obj_field = lwm2m_get_engine_obj_field(obj,
+				obj_inst->resources[i].res_id);
+		if (!obj_field) {
+			LOG_ERR("unable to find obj_field: %u/%u/%u",
+				path->obj_id, path->obj_inst_id,
+				path->res_id);
+			return -ENOENT;
+		}
+
+		/* check for READ permission on matching resource */
+		if (!LWM2M_HAS_PERM(obj_field, LWM2M_PERM_R)) {
+			return -EPERM;
+		}
+
+		ret = update_attrs(&obj_inst->resources[i], attrs);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	/* check if resource instance exists */
+	if (IS_ENABLED(CONFIG_LWM2M_VERSION_1_1) &&
+	    path->level == LWM2M_PATH_LEVEL_RESOURCE_INST) {
+		ret = path_to_objs(path, NULL, NULL, NULL, &res_inst);
+		if (ret < 0) {
+			return ret;
+		}
+
+		if (res_inst == NULL) {
+			return -ENOENT;
+		}
+
+		ret = update_attrs(res_inst, attrs);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	attrs->pmax = (attrs->pmax >= attrs->pmin) ? (uint32_t)attrs->pmax : 0UL;
+
+	return 0;
+}
+
+int lwm2m_notify_observer_path(struct lwm2m_obj_path *path)
+{
 	struct observe_node *obs;
+	struct notification_attrs nattrs = { 0 };
+	int64_t timestamp;
 	int ret = 0;
 	int i;
 
+	if (path->level < LWM2M_PATH_LEVEL_RESOURCE) {
+		return 0;
+	}
+
 	/* look for observers which match our resource */
 	for (i = 0; i < sock_nfds; ++i) {
-		SYS_SLIST_FOR_EACH_CONTAINER(&sock_ctx[i]->observer, obs, node) {
-			if (obs->path.obj_id == obj_id &&
-			    obs->path.obj_inst_id == obj_inst_id &&
-			    (obs->path.level < 3 ||
-			     obs->path.res_id == res_id)) {
+		SYS_SLIST_FOR_EACH_CONTAINER (&sock_ctx[i]->observer, obs, node) {
+			if (lwm2m_observer_path_compare(&obs->path, path)) {
 				/* update the event time for this observer */
-				obs->event_timestamp = k_uptime_get();
+				ret = engine_observe_get_attributes(&obs->path, &nattrs,
+								    sock_ctx[i]->srv_obj_inst);
+				if (ret < 0) {
+					return ret;
+				}
+				if (nattrs.pmin) {
+					timestamp =
+						obs->last_timestamp + MSEC_PER_SEC * nattrs.pmin;
+				} else {
+					/* Trig immediately */
+					timestamp = k_uptime_get();
+				}
 
-				LOG_DBG("NOTIFY EVENT %u/%u/%u",
-					obj_id, obj_inst_id, res_id);
+				if (!obs->event_timestamp || obs->event_timestamp > timestamp) {
+					obs->resource_update = true;
+					obs->event_timestamp = timestamp;
+				}
+
+				LOG_DBG("NOTIFY EVENT %u/%u/%u", path->obj_id, path->obj_inst_id,
+					path->res_id);
 
 				ret++;
 			}
@@ -389,27 +559,30 @@ int lwm2m_notify_observer(uint16_t obj_id, uint16_t obj_inst_id, uint16_t res_id
 	}
 
 	return ret;
+
 }
 
-int lwm2m_notify_observer_path(struct lwm2m_obj_path *path)
+static struct observe_node *engine_allocate_observer(void)
 {
-	return lwm2m_notify_observer(path->obj_id, path->obj_inst_id,
-				     path->res_id);
+	int i;
+
+	/* find an unused observer index node */
+	for (i = 0; i < CONFIG_LWM2M_ENGINE_MAX_OBSERVER; i++) {
+		if (!observe_node_data[i].tkl) {
+			return &observe_node_data[i];
+		}
+	}
+
+	return NULL;
 }
 
 static int engine_add_observer(struct lwm2m_message *msg,
 			       const uint8_t *token, uint8_t tkl,
 			       uint16_t format)
 {
-	struct lwm2m_engine_obj *obj = NULL;
-	struct lwm2m_engine_obj_field *obj_field = NULL;
-	struct lwm2m_engine_obj_inst *obj_inst = NULL;
-	struct lwm2m_engine_res_inst *res_inst = NULL;
 	struct observe_node *obs;
-	struct notification_attrs attrs = {
-		.flags = BIT(LWM2M_ATTR_PMIN) | BIT(LWM2M_ATTR_PMAX),
-	};
-	int i, ret;
+	struct notification_attrs attrs;
+	int ret;
 
 	if (!msg || !msg->ctx) {
 		LOG_ERR("valid lwm2m message is required");
@@ -421,10 +594,6 @@ static int engine_add_observer(struct lwm2m_message *msg,
 			token, tkl);
 		return -EINVAL;
 	}
-
-	/* defaults from server object */
-	attrs.pmin = lwm2m_server_get_pmin(msg->ctx->srv_obj_inst);
-	attrs.pmax = lwm2m_server_get_pmax(msg->ctx->srv_obj_inst);
 
 	/* TODO: observe dup checking */
 
@@ -446,114 +615,32 @@ static int engine_add_observer(struct lwm2m_message *msg,
 		}
 	}
 
-	/* check if object exists */
-	obj = get_engine_obj(msg->path.obj_id);
-	if (!obj) {
-		LOG_ERR("unable to find obj: %u", msg->path.obj_id);
-		return -ENOENT;
-	}
-
-	ret = update_attrs(obj, &attrs);
+	ret = engine_observe_get_attributes(&msg->path, &attrs, msg->ctx->srv_obj_inst);
 	if (ret < 0) {
 		return ret;
 	}
 
-	/* check if object instance exists */
-	if (msg->path.level >= LWM2M_PATH_LEVEL_OBJECT_INST) {
-		obj_inst = get_engine_obj_inst(msg->path.obj_id,
-					       msg->path.obj_inst_id);
-		if (!obj_inst) {
-			LOG_ERR("unable to find obj_inst: %u/%u",
-				msg->path.obj_id, msg->path.obj_inst_id);
-			return -ENOENT;
-		}
-
-		ret = update_attrs(obj_inst, &attrs);
-		if (ret < 0) {
-			return ret;
-		}
-	}
-
-	/* check if resource exists */
-	if (msg->path.level >= LWM2M_PATH_LEVEL_RESOURCE) {
-		for (i = 0; i < obj_inst->resource_count; i++) {
-			if (obj_inst->resources[i].res_id == msg->path.res_id) {
-				break;
-			}
-		}
-
-		if (i == obj_inst->resource_count) {
-			LOG_ERR("unable to find res_id: %u/%u/%u",
-				msg->path.obj_id, msg->path.obj_inst_id,
-				msg->path.res_id);
-			return -ENOENT;
-		}
-
-		/* load object field data */
-		obj_field = lwm2m_get_engine_obj_field(obj,
-				obj_inst->resources[i].res_id);
-		if (!obj_field) {
-			LOG_ERR("unable to find obj_field: %u/%u/%u",
-				msg->path.obj_id, msg->path.obj_inst_id,
-				msg->path.res_id);
-			return -ENOENT;
-		}
-
-		/* check for READ permission on matching resource */
-		if (!LWM2M_HAS_PERM(obj_field, LWM2M_PERM_R)) {
-			return -EPERM;
-		}
-
-		ret = update_attrs(&obj_inst->resources[i], &attrs);
-		if (ret < 0) {
-			return ret;
-		}
-	}
-
-	/* check if resource instance exists */
-	if (IS_ENABLED(CONFIG_LWM2M_VERSION_1_1) &&
-	    msg->path.level == LWM2M_PATH_LEVEL_RESOURCE_INST) {
-		ret = path_to_objs(&msg->path, NULL, NULL, NULL, &res_inst);
-		if (ret < 0) {
-			return ret;
-		}
-
-		if (res_inst == NULL) {
-			return -ENOENT;
-		}
-
-		ret = update_attrs(res_inst, &attrs);
-		if (ret < 0) {
-			return ret;
-		}
-	}
-
-	/* find an unused observer index node */
-	for (i = 0; i < CONFIG_LWM2M_ENGINE_MAX_OBSERVER; i++) {
-		if (!observe_node_data[i].tkl) {
-			break;
-		}
-	}
-
-	/* couldn't find an index */
-	if (i == CONFIG_LWM2M_ENGINE_MAX_OBSERVER) {
+	obs = engine_allocate_observer();
+	if (!obs) {
 		return -ENOMEM;
 	}
 
 	/* copy the values and add it to the list */
-	memcpy(&observe_node_data[i].path, &msg->path, sizeof(msg->path));
-	memcpy(observe_node_data[i].token, token, tkl);
-	observe_node_data[i].tkl = tkl;
-	observe_node_data[i].last_timestamp = k_uptime_get();
-	observe_node_data[i].event_timestamp =
-			observe_node_data[i].last_timestamp;
-	observe_node_data[i].min_period_sec = attrs.pmin;
-	observe_node_data[i].max_period_sec = (attrs.pmax >= attrs.pmin) ?
-						(uint32_t)attrs.pmax : 0UL;
-	observe_node_data[i].format = format;
-	observe_node_data[i].counter = OBSERVE_COUNTER_START;
+	memcpy(&obs->path, &msg->path, sizeof(msg->path));
+	memcpy(obs->token, token, tkl);
+	obs->tkl = tkl;
+
+	obs->last_timestamp = k_uptime_get();
+	if (attrs.pmax) {
+		obs->event_timestamp = obs->last_timestamp + MSEC_PER_SEC * attrs.pmax;
+	} else {
+		obs->event_timestamp = 0;
+	}
+	obs->resource_update = false;
+	obs->format = format;
+	obs->counter = OBSERVE_COUNTER_START;
 	sys_slist_append(&msg->ctx->observer,
-			 &observe_node_data[i].node);
+			 &obs->node);
 
 	LOG_DBG("OBSERVER ADDED %u/%u/%u/%u(%u) token:'%s' addr:%s",
 		msg->path.obj_id, msg->path.obj_inst_id,
@@ -2034,56 +2121,245 @@ int lwm2m_engine_get_resource(const char *pathstr, struct lwm2m_engine_res **res
 	return path_to_objs(&path, NULL, NULL, res, NULL);
 }
 
-int lwm2m_engine_update_observer_min_period(const char *pathstr, uint32_t period_s)
+static int lwm2m_update_or_allocate_attribute(void *ref, uint8_t type, void *data)
 {
-	int i, ret;
-	struct lwm2m_obj_path path;
+	struct lwm2m_attr *attr;
+	int i;
 
-	ret = string_to_path(pathstr, &path, '/');
-	if (ret < 0) {
-		return ret;
+	/* find matching attributes */
+	for (i = 0; i < CONFIG_LWM2M_NUM_ATTR; i++) {
+		if (ref != write_attr_pool[i].ref || write_attr_pool[i].type != type) {
+			continue;
+		}
+
+		attr = write_attr_pool + i;
+		type = attr->type;
+
+		if (type <= LWM2M_ATTR_PMAX) {
+			attr->int_val = *(int32_t *)data;
+			LOG_DBG("Update %s to %d", log_strdup(LWM2M_ATTR_STR[type]),
+				attr->int_val);
+		} else {
+			attr->float_val = *(double *)data;
+			LOG_DBG("Update %s to %f", log_strdup(LWM2M_ATTR_STR[type]),
+				attr->float_val);
+		}
+		return 0;
 	}
 
-	for (i = 0; i < CONFIG_LWM2M_ENGINE_MAX_OBSERVER; i++) {
-		if (observe_node_data[i].path.level == path.level &&
-		    observe_node_data[i].path.obj_id == path.obj_id &&
-		    (path.level >= 2 ?
-		     observe_node_data[i].path.obj_inst_id == path.obj_inst_id : true) &&
-		    (path.level >= 3 ?
-		     observe_node_data[i].path.res_id == path.res_id : true)) {
-
-			observe_node_data[i].min_period_sec = period_s;
-			return 0;
+	/* add attribute to obj/obj_inst/res/res_inst */
+	/* grab an entry for newly added attribute */
+	for (i = 0; i < CONFIG_LWM2M_NUM_ATTR; i++) {
+		if (!write_attr_pool[i].ref) {
+			break;
 		}
 	}
 
-	return -ENOENT;
+	if (i == CONFIG_LWM2M_NUM_ATTR) {
+		return -ENOMEM;
+	}
+
+	attr = write_attr_pool + i;
+	attr->type = type;
+	attr->ref = ref;
+
+	if (type <= LWM2M_ATTR_PMAX) {
+		attr->int_val = *(int32_t *)data;
+		LOG_DBG("Add %s to %d", log_strdup(LWM2M_ATTR_STR[type]), attr->int_val);
+	} else {
+		attr->float_val = *(double *)data;
+		LOG_DBG("Add %s to %f", log_strdup(LWM2M_ATTR_STR[type]), attr->float_val);
+	}
+	return 0;
 }
 
-int lwm2m_engine_update_observer_max_period(const char *pathstr, uint32_t period_s)
+static int lwm2m_engine_observer_timestamp_update(sys_slist_t * observer,
+						  struct lwm2m_obj_path * path,
+						  uint16_t srv_obj_inst)
 {
-	int i, ret;
+	struct observe_node *obs;
+	struct notification_attrs nattrs = { 0 };
+	int ret;
+	int64_t timestamp;
+
+
+	/* update observe_node accordingly */
+	SYS_SLIST_FOR_EACH_CONTAINER (observer, obs, node) {
+		if (!obs->resource_update) {
+			/* Resource Update on going skip this*/
+			continue;
+		}
+		/* Compare Obervation node path to updated one */
+		if (!lwm2m_observer_path_compare(&obs->path, path)) {
+			continue;
+		}
+
+		/* Read Atributes after validation Path */
+		ret = engine_observe_get_attributes(&obs->path, &nattrs, srv_obj_inst);
+		if (ret < 0) {
+			return ret;
+		}
+
+		/* Update based on by PMax */
+		if (nattrs.pmax) {
+			/* Update Current */
+			timestamp = obs->last_timestamp + MSEC_PER_SEC * nattrs.pmax;
+		} else {
+			/* Disable Automatic Notify */
+			timestamp = 0;
+		}
+		obs->event_timestamp = timestamp;
+
+		(void)memset(&nattrs, 0, sizeof(nattrs));
+	}
+	return 0;
+}
+
+static int lwm2m_get_path_refence_ptr(struct lwm2m_engine_obj *obj, struct lwm2m_obj_path *path,
+				      void **ref)
+{
+	struct lwm2m_engine_obj_inst *obj_inst;
+	struct lwm2m_engine_res *res;
+	struct lwm2m_engine_res_inst *res_inst;
+	int ret;
+
+	if (!obj) {
+		/* Discover Object */
+		obj = get_engine_obj(path->obj_id);
+		if (!obj) {
+			/* No matching object found - ignore request */
+			return -ENOENT;
+		}
+	}
+
+	if (path->level == LWM2M_PATH_LEVEL_OBJECT) {
+		*ref = obj;
+	} else if (path->level == LWM2M_PATH_LEVEL_OBJECT_INST) {
+		obj_inst = get_engine_obj_inst(path->obj_id,
+					       path->obj_inst_id);
+		if (!obj_inst) {
+			return -ENOENT;
+		}
+
+		*ref = obj_inst;
+	} else if (path->level == LWM2M_PATH_LEVEL_RESOURCE) {
+		ret = path_to_objs(path, NULL, NULL, &res, NULL);
+		if (ret < 0) {
+			return ret;
+		}
+
+		*ref = res;
+	} else if (IS_ENABLED(CONFIG_LWM2M_VERSION_1_1) &&
+		   path->level == LWM2M_PATH_LEVEL_RESOURCE_INST) {
+
+		ret = path_to_objs(path, NULL, NULL, NULL, &res_inst);
+		if (ret < 0) {
+			return ret;
+		}
+
+		*ref = res_inst;
+	} else {
+		/* bad request */
+		return -EEXIST;
+	}
+
+	return 0;
+}
+
+int lwm2m_engine_update_observer_min_period(struct lwm2m_ctx *client_ctx, const char *pathstr,
+					    uint32_t period_s)
+{
+	int ret;
 	struct lwm2m_obj_path path;
+	struct notification_attrs nattrs = { 0 };
+	struct notification_attrs attrs = { 0 };
+	void *ref;
 
 	ret = string_to_path(pathstr, &path, '/');
 	if (ret < 0) {
 		return ret;
 	}
 
-	for (i = 0; i < CONFIG_LWM2M_ENGINE_MAX_OBSERVER; i++) {
-		if (observe_node_data[i].path.level == path.level &&
-		    observe_node_data[i].path.obj_id == path.obj_id &&
-		    (path.level >= 2 ?
-		     observe_node_data[i].path.obj_inst_id == path.obj_inst_id : true) &&
-		    (path.level >= 3 ?
-		     observe_node_data[i].path.res_id == path.res_id : true)) {
-
-			observe_node_data[i].max_period_sec = period_s;
-			return 0;
-		}
+	/* Read Reference pointer to attribute */
+	ret = lwm2m_get_path_refence_ptr(NULL, &path, &ref);
+	if (ret < 0) {
+		return ret;
+	}
+	/* retrieve existing attributes */
+	ret = update_attrs(ref, &nattrs);
+	if (ret < 0) {
+		return ret;
 	}
 
-	return -ENOENT;
+	if (nattrs.flags & BIT(LWM2M_ATTR_PMIN) && nattrs.pmin == period_s) {
+		/* No need to change */
+		return 0;
+	}
+
+	/* Read  Pmin & Pmax values for path */
+	ret = engine_observe_get_attributes(&path, &attrs, client_ctx->srv_obj_inst);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (period_s && attrs.pmax && attrs.pmax < period_s) {
+		LOG_DBG("New pmin (%d) > pmax (%d)", period_s, attrs.pmax);
+		return -EEXIST;
+	}
+
+	return lwm2m_update_or_allocate_attribute(ref, LWM2M_ATTR_PMIN, &period_s);
+}
+
+int lwm2m_engine_update_observer_max_period(struct lwm2m_ctx *client_ctx, const char *pathstr,
+					    uint32_t period_s)
+{
+	int ret;
+	struct lwm2m_obj_path path;
+	void *ref;
+	struct notification_attrs nattrs = { 0 };
+	struct notification_attrs attrs = { 0 };
+
+	ret = string_to_path(pathstr, &path, '/');
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Read Reference pointer to attribute */
+	ret = lwm2m_get_path_refence_ptr(NULL, &path, &ref);
+	if (ret < 0) {
+		return ret;
+	}
+	/* retrieve existing attributes */
+	ret = update_attrs(ref, &nattrs);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (nattrs.flags & BIT(LWM2M_ATTR_PMAX) && nattrs.pmax == period_s) {
+		/* No need to change */
+		return 0;
+	}
+
+	/* Read  Pmin & Pmax values for path */
+	ret = engine_observe_get_attributes(&path, &attrs, client_ctx->srv_obj_inst);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (period_s && attrs.pmin > period_s) {
+		LOG_DBG("pmin (%d) > new pmax (%d)", attrs.pmin, period_s);
+		return -EEXIST;
+	}
+
+	/* Update or allocate new */
+	ret = lwm2m_update_or_allocate_attribute(ref, LWM2M_ATTR_PMAX, &period_s);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Update Observer timestamp */
+	return lwm2m_engine_observer_timestamp_update(&client_ctx->observer, &path,
+						      client_ctx->srv_obj_inst);
 }
 
 void lwm2m_engine_get_binding(char *binding)
@@ -2881,12 +3157,8 @@ static int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj,
 	char opt_buf[COAP_OPTION_BUF_LEN];
 	int nr_opt, i, ret = 0;
 	struct coap_option options[NR_LWM2M_ATTR];
-	struct lwm2m_engine_obj_inst *obj_inst = NULL;
-	struct lwm2m_engine_res *res = NULL;
-	struct lwm2m_engine_res_inst *res_inst = NULL;
 	struct lwm2m_attr *attr;
 	struct notification_attrs nattrs = { 0 };
-	struct observe_node *obs;
 	uint8_t type = 0U;
 	void *nattr_ptrs[NR_LWM2M_ATTR] = {
 		&nattrs.pmin, &nattrs.pmax, &nattrs.gt, &nattrs.lt, &nattrs.st
@@ -2911,35 +3183,9 @@ static int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj,
 	}
 
 	/* get lwm2m_attr slist */
-	if (msg->path.level == LWM2M_PATH_LEVEL_OBJECT) {
-		ref = obj;
-	} else if (msg->path.level == LWM2M_PATH_LEVEL_OBJECT_INST) {
-		obj_inst = get_engine_obj_inst(msg->path.obj_id,
-					       msg->path.obj_inst_id);
-		if (!obj_inst) {
-			return -ENOENT;
-		}
-
-		ref = obj_inst;
-	} else if (msg->path.level == LWM2M_PATH_LEVEL_RESOURCE) {
-		ret = path_to_objs(&msg->path, NULL, NULL, &res, NULL);
-		if (ret < 0) {
-			return ret;
-		}
-
-		ref = res;
-	} else if (IS_ENABLED(CONFIG_LWM2M_VERSION_1_1) &&
-		   msg->path.level == LWM2M_PATH_LEVEL_RESOURCE_INST) {
-
-		ret = path_to_objs(&msg->path, NULL, NULL, NULL, &res_inst);
-		if (ret < 0) {
-			return ret;
-		}
-
-		ref = res_inst;
-	} else {
-		/* bad request */
-		return -EEXIST;
+	ret = lwm2m_get_path_refence_ptr(obj, &msg->path, &ref);
+	if (ret < 0) {
+		return ret;
 	}
 
 	/* retrieve existing attributes */
@@ -3141,102 +3387,8 @@ static int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj,
 		return 0;
 	}
 
-	/* update observe_node accordingly */
-	SYS_SLIST_FOR_EACH_CONTAINER(&msg->ctx->observer, obs, node) {
-		/* updated path is deeper than obs node, skip */
-		if (msg->path.level > obs->path.level) {
-			continue;
-		}
-
-		/* check obj id matched or not */
-		if (msg->path.obj_id != obs->path.obj_id) {
-			continue;
-		}
-
-		/* defaults from server object */
-		nattrs.pmin = lwm2m_server_get_pmin(msg->ctx->srv_obj_inst);
-		nattrs.pmax = lwm2m_server_get_pmax(msg->ctx->srv_obj_inst);
-
-		ret = update_attrs(obj, &nattrs);
-		if (ret < 0) {
-			return ret;
-		}
-
-		if (obs->path.level >= LWM2M_PATH_LEVEL_OBJECT_INST) {
-			if (msg->path.level >= LWM2M_PATH_LEVEL_OBJECT_INST &&
-			    msg->path.obj_inst_id != obs->path.obj_inst_id) {
-				continue;
-			}
-
-			/* get obj_inst */
-			if (!obj_inst || obj_inst->obj_inst_id !=
-					 obs->path.obj_inst_id) {
-				obj_inst = get_engine_obj_inst(
-						obs->path.obj_id,
-						obs->path.obj_inst_id);
-				if (!obj_inst) {
-					return -ENOENT;
-				}
-			}
-
-			ret = update_attrs(obj_inst, &nattrs);
-			if (ret < 0) {
-				return ret;
-			}
-		}
-
-		if (obs->path.level >= LWM2M_PATH_LEVEL_RESOURCE) {
-			if (msg->path.level >= LWM2M_PATH_LEVEL_RESOURCE &&
-			    msg->path.res_id != obs->path.res_id) {
-				continue;
-			}
-
-			if (!res || res->res_id != obs->path.res_id) {
-				ret = path_to_objs(&obs->path, NULL, NULL,
-						   &res, NULL);
-				if (ret < 0) {
-					return ret;
-				}
-			}
-
-			ret = update_attrs(res, &nattrs);
-			if (ret < 0) {
-				return ret;
-			}
-		}
-
-		if (IS_ENABLED(CONFIG_LWM2M_VERSION_1_1) &&
-		    obs->path.level == LWM2M_PATH_LEVEL_RESOURCE_INST) {
-			if (msg->path.level == LWM2M_PATH_LEVEL_RESOURCE_INST &&
-			    msg->path.res_inst_id != obs->path.res_inst_id) {
-				continue;
-			}
-
-			if (!res_inst || res_inst->res_inst_id != obs->path.res_inst_id) {
-				ret = path_to_objs(&obs->path, NULL, NULL, NULL,
-						   &res_inst);
-				if (ret < 0) {
-					return ret;
-				}
-			}
-
-			ret = update_attrs(res_inst, &nattrs);
-			if (ret < 0) {
-				return ret;
-			}
-		}
-
-		LOG_DBG("%d/%d/%d/%d(%d) updated from %d/%d to %u/%u",
-			obs->path.obj_id, obs->path.obj_inst_id,
-			obs->path.res_id, obs->path.res_inst_id,
-			obs->path.level, obs->min_period_sec,
-			obs->max_period_sec, nattrs.pmin,
-			(nattrs.pmax >= nattrs.pmin) ? nattrs.pmax : 0);
-
-		obs->min_period_sec = (uint32_t)nattrs.pmin;
-		obs->max_period_sec = (uint32_t)MAX(nattrs.pmin, nattrs.pmax);
-		(void)memset(&nattrs, 0, sizeof(nattrs));
-	}
+	lwm2m_engine_observer_timestamp_update(&msg->ctx->observer, &msg->path,
+					       msg->ctx->srv_obj_inst);
 
 	return 0;
 }
@@ -4724,7 +4876,6 @@ static int notify_message_reply_cb(const struct coap_packet *response,
 
 static int generate_notify_message(struct lwm2m_ctx *ctx,
 				   struct observe_node *obs,
-				   bool manual_trigger,
 				   void *user_data)
 {
 	struct lwm2m_message *msg;
@@ -4742,7 +4893,7 @@ static int generate_notify_message(struct lwm2m_ctx *ctx,
 	msg->operation = LWM2M_OP_READ;
 
 	LOG_DBG("[%s] NOTIFY MSG START: %u/%u/%u(%u) token:'%s' [%s] %lld",
-		manual_trigger ? "MANUAL" : "AUTO",
+		obs->resource_update ? "MANUAL" : "AUTO",
 		obs->path.obj_id,
 		obs->path.obj_inst_id,
 		obs->path.res_id,
@@ -4751,6 +4902,7 @@ static int generate_notify_message(struct lwm2m_ctx *ctx,
 		log_strdup(lwm2m_sprint_ip_addr(&ctx->remote_addr)),
 		(long long)k_uptime_get());
 
+	obs->resource_update = false;
 	obj_inst = get_engine_obj_inst(obs->path.obj_id,
 				       obs->path.obj_inst_id);
 	if (!obj_inst) {
@@ -4971,23 +5123,23 @@ void lwm2m_socket_del(struct lwm2m_ctx *ctx)
 	}
 }
 
-static bool manual_notify_is_due(const struct observe_node *obs,
-				 const int64_t timestamp)
+static int64_t engine_observe_shedule_next_event(struct observe_node * obs, uint16_t srv_obj_inst,
+					      const int64_t timestamp)
 {
-	const bool has_min_period = obs->min_period_sec != 0;
+	struct notification_attrs attrs;
+	int64_t t_s = 0;
+	int ret;
 
-	return obs->event_timestamp > obs->last_timestamp &&
-		(!has_min_period || timestamp > obs->last_timestamp +
-		 MSEC_PER_SEC * obs->min_period_sec);
-}
+	ret = engine_observe_get_attributes(&obs->path, &attrs, srv_obj_inst);
+	if (ret < 0) {
+		return 0;
+	}
 
-static bool automatic_notify_is_due(const struct observe_node *obs,
-				    const int64_t timestamp)
-{
-	const bool has_max_period = obs->max_period_sec != 0;
+	if (attrs.pmax) {
+		t_s = timestamp + MSEC_PER_SEC * attrs.pmax;
+	}
 
-	return has_max_period && (timestamp > obs->last_timestamp +
-				  MSEC_PER_SEC * obs->max_period_sec);
+	return t_s;
 }
 
 static void check_notifications(struct lwm2m_ctx *ctx,
@@ -4995,19 +5147,18 @@ static void check_notifications(struct lwm2m_ctx *ctx,
 {
 	struct observe_node *obs;
 	int rc;
-	bool manual_notify, automatic_notify;
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&ctx->observer, obs, node) {
-		manual_notify = manual_notify_is_due(obs, timestamp);
-		automatic_notify = automatic_notify_is_due(obs, timestamp);
-		if (!manual_notify && !automatic_notify) {
+		if (!obs->event_timestamp || timestamp < obs->event_timestamp) {
 			continue;
 		}
-		rc = generate_notify_message(ctx, obs, manual_notify, NULL);
+		rc = generate_notify_message(ctx, obs, NULL);
 		if (rc == -ENOMEM) {
 			/* no memory/messages available, retry later */
 			return;
 		}
+		obs->event_timestamp =
+			engine_observe_shedule_next_event(obs, ctx->srv_obj_inst, timestamp);
 		obs->last_timestamp = timestamp;
 		if (!rc) {
 			/* create at most one notification */

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -31,6 +31,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <net/net_ip.h>
 #include <net/http_parser_url.h>
 #include <net/socket.h>
+#include <net/lwm2m.h>
 #if defined(CONFIG_LWM2M_DTLS_SUPPORT)
 #include <net/tls_credentials.h>
 #endif
@@ -82,15 +83,15 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 struct observe_node {
 	sys_snode_t node;
-	struct lwm2m_obj_path path;
+	sys_slist_t path_list;		/* List of Observation path */
+	bool composite :1; 		/* Composite Observation */
 	bool resource_update :1; 	/* Resource is updated */
 	uint8_t token[MAX_TOKEN_LEN];	/* Observation Token */
 	int64_t event_timestamp;	/* Timestamp for trig next Notify  */
-	int64_t last_timestamp;
+	int64_t last_timestamp;		/* Timestamp from last Notify */
 	uint32_t counter;
 	uint16_t format;
 	uint8_t  tkl;
-
 };
 
 struct notification_attrs {
@@ -103,6 +104,13 @@ struct notification_attrs {
 	uint8_t flags;
 };
 
+#ifdef CONFIG_LWM2M_VERSION_1_1
+#define LWM2M_ENGINE_MAX_OBSERVER_PATH CONFIG_LWM2M_ENGINE_MAX_OBSERVER * 3
+#else
+#define LWM2M_ENGINE_MAX_OBSERVER_PATH CONFIG_LWM2M_ENGINE_MAX_OBSERVER
+#endif
+static struct lwm2m_obj_path_list observe_paths[LWM2M_ENGINE_MAX_OBSERVER_PATH];
+static sys_slist_t obs_obj_path_list;
 static struct observe_node observe_node_data[CONFIG_LWM2M_ENGINE_MAX_OBSERVER];
 
 #define MAX_PERIODIC_SERVICE	10
@@ -159,6 +167,15 @@ static int path_to_objs(const struct lwm2m_obj_path *path,
 			struct lwm2m_engine_obj_field **obj_field,
 			struct lwm2m_engine_res **res,
 			struct lwm2m_engine_res_inst **res_inst);
+
+static struct lwm2m_obj_path *lwm2m_read_first_path_ptr(sys_slist_t *lwm2m_path_list);
+static struct lwm2m_obj_path_list *lwm2m_engine_get_from_list(sys_slist_t *path_list);
+static int do_send_op(struct lwm2m_message *msg, uint16_t content_format,
+		      sys_slist_t *lwm2m_path_list);
+static int do_composite_observe_read_path_op(struct lwm2m_message *msg, uint16_t content_format,
+					     sys_slist_t *lwm2m_path_list,
+					     sys_slist_t *lwm2m_path_free_list);
+static void lwm2m_engine_free_list(sys_slist_t *path_list, sys_slist_t *free_list);
 
 /* for debugging: to print IP addresses */
 char *lwm2m_sprint_ip_addr(const struct sockaddr *addr)
@@ -364,7 +381,6 @@ static void clear_attrs(void *ref)
 	}
 }
 
-
 static bool lwm2m_observer_path_compare(struct lwm2m_obj_path *o_p, struct lwm2m_obj_path *p)
 {
 	/* updated path is deeper than obs node, skip */
@@ -400,6 +416,19 @@ static bool lwm2m_observer_path_compare(struct lwm2m_obj_path *o_p, struct lwm2m
 	}
 
 	return true;
+}
+
+static bool lwm2m_notify_observer_list(sys_slist_t *path_list, struct lwm2m_obj_path *path)
+{
+	struct lwm2m_obj_path_list *o_p;
+
+	SYS_SLIST_FOR_EACH_CONTAINER (path_list, o_p, node) {
+		if (lwm2m_observer_path_compare(&o_p->path, path)) {
+			return true;
+		}
+	}
+
+	return false;
 }
 
 int lwm2m_notify_observer(uint16_t obj_id, uint16_t obj_inst_id, uint16_t res_id)
@@ -445,9 +474,9 @@ static int engine_observe_get_attributes(struct lwm2m_obj_path *path,
 		obj_inst = get_engine_obj_inst(path->obj_id,
 					       path->obj_inst_id);
 		if (!obj_inst) {
-			LOG_ERR("unable to find obj_inst: %u/%u",
-				path->obj_id, path->obj_inst_id);
-			return -ENOENT;
+			attrs->pmax = 0;
+			attrs->pmin = 0;
+			return 0;
 		}
 
 		ret = update_attrs(obj_inst, attrs);
@@ -515,6 +544,46 @@ static int engine_observe_get_attributes(struct lwm2m_obj_path *path,
 	return 0;
 }
 
+int engine_observe_attribute_list_get(sys_slist_t *path_list, struct notification_attrs *nattrs,
+				      uint16_t server_obj_inst)
+{
+	struct lwm2m_obj_path_list *o_p;
+	/* Temporary compare values */
+	int32_t pmin = 0;
+	int32_t pmax = 0;
+	int ret;
+
+	SYS_SLIST_FOR_EACH_CONTAINER (path_list, o_p, node) {
+		nattrs->pmin = 0;
+		nattrs->pmax = 0;
+
+		ret = engine_observe_get_attributes(&o_p->path, nattrs, server_obj_inst);
+		if (ret < 0) {
+			return ret;
+		}
+
+		if (nattrs->pmin) {
+			if (pmin == 0) {
+				pmin = nattrs->pmin;
+			} else {
+				pmin = MIN(pmin, nattrs->pmin);
+			}
+		}
+
+		if (nattrs->pmax) {
+			if (pmax == 0) {
+				pmax = nattrs->pmax;
+			} else {
+				pmax = MIN(pmax, nattrs->pmax);
+			}
+		}
+	}
+
+	nattrs->pmin = pmin;
+	nattrs->pmax = pmax;
+	return 0;
+}
+
 int lwm2m_notify_observer_path(struct lwm2m_obj_path *path)
 {
 	struct observe_node *obs;
@@ -530,13 +599,14 @@ int lwm2m_notify_observer_path(struct lwm2m_obj_path *path)
 	/* look for observers which match our resource */
 	for (i = 0; i < sock_nfds; ++i) {
 		SYS_SLIST_FOR_EACH_CONTAINER (&sock_ctx[i]->observer, obs, node) {
-			if (lwm2m_observer_path_compare(&obs->path, path)) {
+			if (lwm2m_notify_observer_list(&obs->path_list, path)) {
 				/* update the event time for this observer */
-				ret = engine_observe_get_attributes(&obs->path, &nattrs,
+				ret = engine_observe_attribute_list_get(&obs->path_list, &nattrs,
 								    sock_ctx[i]->srv_obj_inst);
 				if (ret < 0) {
 					return ret;
 				}
+
 				if (nattrs.pmin) {
 					timestamp =
 						obs->last_timestamp + MSEC_PER_SEC * nattrs.pmin;
@@ -552,7 +622,6 @@ int lwm2m_notify_observer_path(struct lwm2m_obj_path *path)
 
 				LOG_DBG("NOTIFY EVENT %u/%u/%u", path->obj_id, path->obj_inst_id,
 					path->res_id);
-
 				ret++;
 			}
 		}
@@ -562,17 +631,187 @@ int lwm2m_notify_observer_path(struct lwm2m_obj_path *path)
 
 }
 
-static struct observe_node *engine_allocate_observer(void)
+static struct observe_node *engine_allocate_observer(sys_slist_t *path_list, bool composite)
 {
 	int i;
+	struct lwm2m_obj_path_list *entry, *tmp;
+	struct observe_node *obs = NULL;
 
 	/* find an unused observer index node */
 	for (i = 0; i < CONFIG_LWM2M_ENGINE_MAX_OBSERVER; i++) {
 		if (!observe_node_data[i].tkl) {
-			return &observe_node_data[i];
+
+			obs =  &observe_node_data[i];
+			break;
 		}
 	}
 
+	if (!obs) {
+		return NULL;
+	}
+
+	sys_slist_init(&obs->path_list);
+	obs->composite = composite;
+
+	/* Allocate and copy path */
+	SYS_SLIST_FOR_EACH_CONTAINER(path_list, tmp, node) {
+		/* Allocate path entry */
+		entry = lwm2m_engine_get_from_list(&obs_obj_path_list);
+		if (!entry) {
+			/* Free list */
+			lwm2m_engine_free_list(&obs->path_list, &obs_obj_path_list);
+			return NULL;
+		}
+
+		/* copy the values and add it to the list */
+		memcpy(&entry->path, &tmp->path, sizeof(tmp->path));
+		/* Add to last by keeping already sorted order */
+		sys_slist_append(&obs->path_list, &entry->node);
+	}
+
+	return obs;
+}
+
+static void engine_observe_node_init(struct observe_node *obs, const uint8_t *token,
+				     struct lwm2m_ctx *ctx, uint8_t tkl, uint16_t format,
+				     int32_t att_pmax)
+{
+	struct lwm2m_obj_path_list *tmp;
+
+	memcpy(obs->token, token, tkl);
+	obs->tkl = tkl;
+
+	obs->last_timestamp = k_uptime_get();
+	if (att_pmax) {
+		obs->event_timestamp = obs->last_timestamp + MSEC_PER_SEC * att_pmax;
+	} else {
+		obs->event_timestamp = 0;
+	}
+	obs->resource_update = false;
+	obs->format = format;
+	obs->counter = OBSERVE_COUNTER_START;
+	sys_slist_append(&ctx->observer,
+			 &obs->node);
+
+	SYS_SLIST_FOR_EACH_CONTAINER (&obs->path_list, tmp, node) {
+		LOG_DBG("OBSERVER ADDED %u/%u/%u/%u(%u)", tmp->path.obj_id, tmp->path.obj_inst_id,
+			tmp->path.res_id, tmp->path.res_inst_id, tmp->path.level);
+
+		if (ctx->observe_cb) {
+			ctx->observe_cb(LWM2M_OBSERVE_EVENT_OBSERVER_ADDED, &tmp->path, NULL);
+		}
+	}
+
+	LOG_DBG("token:'%s' addr:%s", log_strdup(sprint_token(token, tkl)),
+		log_strdup(lwm2m_sprint_ip_addr(&ctx->remote_addr)));
+}
+
+static void remove_observer_path_from_list(struct lwm2m_ctx *ctx, struct observe_node *obs,
+				      struct lwm2m_obj_path_list *o_p, sys_snode_t *prev_node)
+{
+	char buf[LWM2M_MAX_PATH_STR_LEN];
+
+	LOG_DBG("Removing observer %p for path %s", obs, lwm2m_path_log_strdup(buf, &o_p->path));
+	if (ctx->observe_cb) {
+		ctx->observe_cb(LWM2M_OBSERVE_EVENT_OBSERVER_REMOVED, &o_p->path, NULL);
+	}
+	/* Remove from the list and add to free list */
+	sys_slist_remove(&obs->path_list, prev_node, &o_p->node);
+	sys_slist_append(&obs_obj_path_list, &o_p->node);
+}
+
+static void engine_observe_single_path_id_remove(struct lwm2m_ctx *ctx, struct observe_node *obs,
+						 uint16_t obj_id, int32_t obj_inst_id)
+{
+	struct lwm2m_obj_path_list *o_p, *tmp;
+	sys_snode_t *prev_node = NULL;
+
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE (&obs->path_list, o_p, tmp, node) {
+		if (o_p->path.obj_id != obj_id && o_p->path.obj_inst_id) {
+			prev_node = &o_p->node;
+			continue;
+		}
+
+		if (obj_inst_id == -1 || o_p->path.obj_inst_id == obj_inst_id) {
+			remove_observer_path_from_list(ctx, obs, o_p, prev_node);
+		} else {
+			prev_node = &o_p->node;
+		}
+	}
+}
+
+static bool engine_compare_obs_path_list(sys_slist_t *obs_path_list, sys_slist_t *path_list,
+					 int list_length)
+{
+	sys_snode_t *obs_ptr, *comp_ptr;
+	struct lwm2m_obj_path_list *obs_path, *comp_path;
+
+	obs_ptr = sys_slist_peek_head(obs_path_list);
+	comp_ptr = sys_slist_peek_head(obs_path_list);
+	while (list_length--) {
+		obs_path = (struct lwm2m_obj_path_list *) obs_ptr;
+		comp_path = (struct lwm2m_obj_path_list *) comp_ptr;
+		if (memcmp(&obs_path->path, &comp_path->path, sizeof(struct lwm2m_obj_path))) {
+			return false;
+		}
+		/* Read Next Info from list entry*/
+		obs_ptr = sys_slist_peek_next_no_check(obs_ptr);
+		comp_ptr = sys_slist_peek_next_no_check(comp_ptr);
+	}
+
+	return true;
+}
+
+static int engine_path_list_size(sys_slist_t *lwm2m_path_list)
+{
+	int list_size = 0;
+	struct lwm2m_obj_path_list *entry;
+
+	SYS_SLIST_FOR_EACH_CONTAINER (lwm2m_path_list, entry, node) {
+		list_size++;
+	}
+	return list_size;
+}
+
+static struct observe_node *engine_observe_node_discover(sys_slist_t *observe_node_list,
+							sys_snode_t **prev_node,
+							sys_slist_t *lwm2m_path_list,
+							const uint8_t *token, uint8_t tkl)
+{
+	struct observe_node *obs;
+	int obs_list_size, path_list_size;
+
+	if (lwm2m_path_list) {
+		path_list_size = engine_path_list_size(lwm2m_path_list);
+	}
+
+	*prev_node = NULL;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(observe_node_list, obs, node) {
+
+		if (lwm2m_path_list) {
+			/* Validate Path for discovery */
+			obs_list_size = engine_path_list_size(&obs->path_list);
+
+			if (obs_list_size != path_list_size) {
+				*prev_node = &obs->node;
+				continue;
+			}
+
+			if (!engine_compare_obs_path_list(&obs->path_list, lwm2m_path_list,
+							  obs_list_size)) {
+				*prev_node = &obs->node;
+				continue;
+			}
+		}
+
+		if (token && memcmp(obs->token, token, tkl)) {
+			/* Token not match */
+			*prev_node = &obs->node;
+			continue;
+		}
+		return obs;
+	}
 	return NULL;
 }
 
@@ -582,6 +821,9 @@ static int engine_add_observer(struct lwm2m_message *msg,
 {
 	struct observe_node *obs;
 	struct notification_attrs attrs;
+	struct lwm2m_obj_path_list obs_path_list_buf;
+	sys_slist_t lwm2m_path_list;
+	sys_snode_t *prev_node = NULL;
 	int ret;
 
 	if (!msg || !msg->ctx) {
@@ -595,84 +837,113 @@ static int engine_add_observer(struct lwm2m_message *msg,
 		return -EINVAL;
 	}
 
-	/* TODO: observe dup checking */
+	/* Create 1 entry linked list for message path */
+	memcpy(&obs_path_list_buf.path, &msg->path, sizeof(struct lwm2m_obj_path));
+	sys_slist_init(&lwm2m_path_list);
+	sys_slist_append(&lwm2m_path_list, &obs_path_list_buf.node);
 
-	/* make sure this observer doesn't exist already */
-	SYS_SLIST_FOR_EACH_CONTAINER(&msg->ctx->observer, obs, node) {
-		/* TODO: distinguish server object */
-		if (memcmp(&obs->path, &msg->path, sizeof(msg->path)) == 0) {
-			/* quietly update the token information */
-			memcpy(obs->token, token, tkl);
-			obs->tkl = tkl;
+	obs = engine_observe_node_discover(&msg->ctx->observer, &prev_node, &lwm2m_path_list, NULL,
+					   0);
+	if (obs) {
+		memcpy(obs->token, token, tkl);
+		obs->tkl = tkl;
 
-			LOG_DBG("OBSERVER DUPLICATE %u/%u/%u(%u) [%s]",
-				msg->path.obj_id, msg->path.obj_inst_id,
-				msg->path.res_id, msg->path.level,
-				log_strdup(
-				lwm2m_sprint_ip_addr(&msg->ctx->remote_addr)));
+		LOG_DBG("OBSERVER DUPLICATE %u/%u/%u(%u) [%s]", msg->path.obj_id,
+			msg->path.obj_inst_id, msg->path.res_id, msg->path.level,
+			log_strdup(lwm2m_sprint_ip_addr(&msg->ctx->remote_addr)));
 
-			return 0;
-		}
+		return 0;
 	}
 
+	/* Read attributes and allocate new entry */
 	ret = engine_observe_get_attributes(&msg->path, &attrs, msg->ctx->srv_obj_inst);
 	if (ret < 0) {
 		return ret;
 	}
 
-	obs = engine_allocate_observer();
+	obs = engine_allocate_observer(&lwm2m_path_list, false);
 	if (!obs) {
 		return -ENOMEM;
 	}
 
-	/* copy the values and add it to the list */
-	memcpy(&obs->path, &msg->path, sizeof(msg->path));
-	memcpy(obs->token, token, tkl);
-	obs->tkl = tkl;
+	engine_observe_node_init(obs, token, msg->ctx, tkl, format, attrs.pmax);
+	return 0;
+}
 
-	obs->last_timestamp = k_uptime_get();
-	if (attrs.pmax) {
-		obs->event_timestamp = obs->last_timestamp + MSEC_PER_SEC * attrs.pmax;
-	} else {
-		obs->event_timestamp = 0;
-	}
-	obs->resource_update = false;
-	obs->format = format;
-	obs->counter = OBSERVE_COUNTER_START;
-	sys_slist_append(&msg->ctx->observer,
-			 &obs->node);
+static int engine_add_composite_observer(struct lwm2m_message *msg,
+			       const uint8_t *token, uint8_t tkl,
+			       uint16_t format)
+{
+	struct observe_node *obs;
+	struct notification_attrs attrs;
+	struct lwm2m_obj_path_list lwm2m_path_list_buf[CONFIG_LWM2M_COMPOSITE_PATH_LIST_SIZE];
+	sys_slist_t lwm2m_path_list;
+	sys_slist_t lwm2m_path_free_list;
+	sys_snode_t *prev_node = NULL;
+	int ret;
 
-	LOG_DBG("OBSERVER ADDED %u/%u/%u/%u(%u) token:'%s' addr:%s",
-		msg->path.obj_id, msg->path.obj_inst_id,
-		msg->path.res_id, msg->path.res_inst_id, msg->path.level,
-		log_strdup(sprint_token(token, tkl)),
-		log_strdup(lwm2m_sprint_ip_addr(&msg->ctx->remote_addr)));
-
-	if (msg->ctx->observe_cb) {
-		msg->ctx->observe_cb(LWM2M_OBSERVE_EVENT_OBSERVER_ADDED, &msg->path, NULL);
+	if (!msg || !msg->ctx) {
+		LOG_ERR("valid lwm2m message is required");
+		return -EINVAL;
 	}
 
+	if (!token || (tkl == 0U || tkl > MAX_TOKEN_LEN)) {
+		LOG_ERR("token(%p) and token length(%u) must be valid.",
+			token, tkl);
+		return -EINVAL;
+	}
+
+	/* Init list */
+	lwm2m_engine_path_list_init(&lwm2m_path_list, &lwm2m_path_free_list, lwm2m_path_list_buf,
+				    CONFIG_LWM2M_COMPOSITE_PATH_LIST_SIZE);
+
+	/* Read attributes and allocate new entry */
+	ret = do_composite_observe_read_path_op(msg, format, &lwm2m_path_list,
+						&lwm2m_path_free_list);
+	if (ret < 0) {
+		return ret;
+	}
+
+	obs = engine_observe_node_discover(&msg->ctx->observer, &prev_node, &lwm2m_path_list, NULL,
+					   0);
+	if (obs) {
+		memcpy(obs->token, token, tkl);
+		obs->tkl = tkl;
+
+		LOG_DBG("OBSERVER Composite DUPLICATE [%s]",
+			log_strdup(lwm2m_sprint_ip_addr(&msg->ctx->remote_addr)));
+
+		return 0;
+	}
+
+	ret = engine_observe_attribute_list_get(&lwm2m_path_list, &attrs, msg->ctx->srv_obj_inst);
+	if (ret < 0) {
+		return ret;
+	}
+
+	obs = engine_allocate_observer(&lwm2m_path_list, true);
+	if (!obs) {
+		return -ENOMEM;
+	}
+	engine_observe_node_init(obs, token, msg->ctx, tkl, format, attrs.pmax);
 	return 0;
 }
 
 static void remove_observer_from_list(struct lwm2m_ctx *ctx, sys_snode_t *prev_node,
 				      struct observe_node *obs)
 {
-	char buf[LWM2M_MAX_PATH_STR_LEN];
+	struct lwm2m_obj_path_list *o_p, *tmp;
 
-	LOG_DBG("Removing observer %p for path %s", obs, lwm2m_path_log_strdup(buf, &obs->path));
-
-	if (ctx->observe_cb) {
-		ctx->observe_cb(LWM2M_OBSERVE_EVENT_OBSERVER_REMOVED, &obs->path, NULL);
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE (&obs->path_list, o_p, tmp, node) {
+		remove_observer_path_from_list(ctx, obs, o_p, NULL);
 	}
-
 	sys_slist_remove(&ctx->observer, prev_node, &obs->node);
 	(void)memset(obs, 0, sizeof(*obs));
 }
 
 static int engine_remove_observer_by_token(struct lwm2m_ctx *ctx, const uint8_t *token, uint8_t tkl)
 {
-	struct observe_node *obs, *found_obj = NULL;
+	struct observe_node *obs;
 	sys_snode_t *prev_node = NULL;
 
 	if (!token || (tkl == 0U || tkl > MAX_TOKEN_LEN)) {
@@ -681,21 +952,51 @@ static int engine_remove_observer_by_token(struct lwm2m_ctx *ctx, const uint8_t 
 		return -EINVAL;
 	}
 
-	/* find the node index */
-	SYS_SLIST_FOR_EACH_CONTAINER(&ctx->observer, obs, node) {
-		if (memcmp(obs->token, token, tkl) == 0) {
-			found_obj = obs;
-			break;
-		}
-
-		prev_node = &obs->node;
-	}
-
-	if (!found_obj) {
+	obs = engine_observe_node_discover(&ctx->observer, &prev_node, NULL, token, tkl);
+	if (!obs) {
 		return -ENOENT;
 	}
 
-	remove_observer_from_list(ctx, prev_node, found_obj);
+	remove_observer_from_list(ctx, prev_node, obs);
+
+	LOG_DBG("observer '%s' removed", log_strdup(sprint_token(token, tkl)));
+
+	return 0;
+}
+
+static int engine_remove_composite_observer(struct lwm2m_message *msg, const uint8_t *token,
+					    uint8_t tkl, uint16_t format)
+{
+	struct observe_node *obs;
+	sys_snode_t *prev_node = NULL;
+	struct lwm2m_obj_path_list lwm2m_path_list_buf[CONFIG_LWM2M_COMPOSITE_PATH_LIST_SIZE];
+	sys_slist_t lwm2m_path_list;
+	sys_slist_t lwm2m_path_free_list;
+	int ret;
+
+	if (!token || (tkl == 0U || tkl > MAX_TOKEN_LEN)) {
+		LOG_ERR("token(%p) and token length(%u) must be valid.",
+			token, tkl);
+		return -EINVAL;
+	}
+
+	/* Init list */
+	lwm2m_engine_path_list_init(&lwm2m_path_list, &lwm2m_path_free_list, lwm2m_path_list_buf,
+				    CONFIG_LWM2M_COMPOSITE_PATH_LIST_SIZE);
+
+	ret = do_composite_observe_read_path_op(msg, format, &lwm2m_path_list,
+						&lwm2m_path_free_list);
+	if (ret < 0) {
+		return ret;
+	}
+
+	obs = engine_observe_node_discover(&msg->ctx->observer, &prev_node, &lwm2m_path_list, token,
+					   tkl);
+	if (!obs) {
+		return -ENOENT;
+	}
+
+	remove_observer_from_list(msg->ctx, prev_node, obs);
 
 	LOG_DBG("observer '%s' removed", log_strdup(sprint_token(token, tkl)));
 
@@ -705,7 +1006,14 @@ static int engine_remove_observer_by_token(struct lwm2m_ctx *ctx, const uint8_t 
 #if defined(CONFIG_LOG)
 char *lwm2m_path_log_strdup(char *buf, struct lwm2m_obj_path *path)
 {
-	size_t cur = sprintf(buf, "%u", path->obj_id);
+	size_t cur;
+
+	if (!path) {
+		sprintf(buf, "/");
+		return log_strdup(buf);
+	}
+
+	cur = sprintf(buf, "%u", path->obj_id);
 
 	if (path->level > 1) {
 		cur += sprintf(buf + cur, "/%u", path->obj_inst_id);
@@ -726,27 +1034,25 @@ static int engine_remove_observer_by_path(struct lwm2m_ctx *ctx,
 					  struct lwm2m_obj_path *path)
 {
 	char buf[LWM2M_MAX_PATH_STR_LEN];
-	struct observe_node *obs, *found_obj = NULL;
+	struct observe_node *obs;
+	struct lwm2m_obj_path_list obs_path_list_buf;
+	sys_slist_t lwm2m_path_list;
 	sys_snode_t *prev_node = NULL;
 
-	/* find the node index */
-	SYS_SLIST_FOR_EACH_CONTAINER(&ctx->observer, obs, node) {
-		if (memcmp(path, &obs->path, sizeof(*path)) == 0) {
-			found_obj = obs;
-			break;
-		}
+	/* Create 1 entry linked list for message path */
+	memcpy(&obs_path_list_buf.path, path, sizeof(struct lwm2m_obj_path));
+	sys_slist_init(&lwm2m_path_list);
+	sys_slist_append(&lwm2m_path_list, &obs_path_list_buf.node);
 
-		prev_node = &obs->node;
-	}
-
-	if (!found_obj) {
+	obs = engine_observe_node_discover(&ctx->observer, &prev_node, &lwm2m_path_list, NULL, 0);
+	if (!obs) {
 		return -ENOENT;
 	}
 
 	LOG_INF("Removing observer for path %s",
 		lwm2m_path_log_strdup(buf, path));
 
-	remove_observer_from_list(ctx, prev_node, found_obj);
+	remove_observer_from_list(ctx, prev_node, obs);
 
 	return 0;
 }
@@ -762,13 +1068,14 @@ static void engine_remove_observer_by_id(uint16_t obj_id, int32_t obj_inst_id)
 	for (i = 0; i < sock_nfds; ++i) {
 		SYS_SLIST_FOR_EACH_CONTAINER_SAFE(
 			&sock_ctx[i]->observer, obs, tmp, node) {
-			if (!(obj_id == obs->path.obj_id &&
-			      obj_inst_id == obs->path.obj_inst_id)) {
-				prev_node = &obs->node;
-				continue;
-			}
+			engine_observe_single_path_id_remove(sock_ctx[i], obs, obj_id,
+							     obj_inst_id);
 
-			remove_observer_from_list(sock_ctx[i], prev_node, obs);
+			if (sys_slist_is_empty(&obs->path_list)) {
+				remove_observer_from_list(sock_ctx[i], prev_node, obs);
+			} else {
+				prev_node = &obs->node;
+			}
 		}
 	}
 }
@@ -2182,7 +2489,6 @@ static int lwm2m_engine_observer_timestamp_update(sys_slist_t * observer,
 	int ret;
 	int64_t timestamp;
 
-
 	/* update observe_node accordingly */
 	SYS_SLIST_FOR_EACH_CONTAINER (observer, obs, node) {
 		if (!obs->resource_update) {
@@ -2190,12 +2496,12 @@ static int lwm2m_engine_observer_timestamp_update(sys_slist_t * observer,
 			continue;
 		}
 		/* Compare Obervation node path to updated one */
-		if (!lwm2m_observer_path_compare(&obs->path, path)) {
+		if (!lwm2m_notify_observer_list(&obs->path_list, path)) {
 			continue;
 		}
 
 		/* Read Atributes after validation Path */
-		ret = engine_observe_get_attributes(&obs->path, &nattrs, srv_obj_inst);
+		ret = engine_observe_attribute_list_get(&obs->path_list, &nattrs, srv_obj_inst);
 		if (ret < 0) {
 			return ret;
 		}
@@ -3507,6 +3813,24 @@ static int do_composite_read_op(struct lwm2m_message *msg, uint16_t content_form
 	}
 }
 
+static int do_composite_observe_read_path_op(struct lwm2m_message *msg, uint16_t content_format,
+					     sys_slist_t *lwm2m_path_list,
+					     sys_slist_t *lwm2m_path_free_list)
+{
+	switch (content_format) {
+#if defined(CONFIG_LWM2M_RW_SENML_JSON_SUPPORT)
+	case LWM2M_FORMAT_APP_SEML_JSON:
+		return do_composite_observe_parse_path_senml_json(msg, lwm2m_path_list,
+								  lwm2m_path_free_list);
+#endif
+
+	default:
+		LOG_ERR("Unsupported content-format: %u", content_format);
+		return -ENOMSG;
+
+	}
+}
+
 static int lwm2m_perform_read_object_instance(struct lwm2m_message *msg,
 					      struct lwm2m_engine_obj_inst *obj_inst,
 					      uint8_t *num_read)
@@ -4134,7 +4458,8 @@ static bool lwm2m_engine_path_included(uint8_t code, bool bootstrap_mode)
 	return true;
 }
 
-static int lwm2m_engine_observation_handler(struct lwm2m_message *msg, int observe, uint16_t accept)
+static int lwm2m_engine_observation_handler(struct lwm2m_message *msg, int observe, uint16_t accept,
+					    bool composite)
 {
 	int r;
 
@@ -4147,23 +4472,34 @@ static int lwm2m_engine_observation_handler(struct lwm2m_message *msg, int obser
 			return r;
 		}
 
-		r = engine_add_observer(msg, msg->token, msg->tkl, accept);
+		if (composite) {
+			r = engine_add_composite_observer(msg, msg->token, msg->tkl, accept);
+		} else {
+			r = engine_add_observer(msg, msg->token, msg->tkl, accept);
+		}
+
 		if (r < 0) {
 			LOG_ERR("add OBSERVE error: %d", r);
 		}
 	} else if (observe == 1) {
 		/* remove observer */
-		r = engine_remove_observer_by_token(msg->ctx, msg->token, msg->tkl);
-		if (r < 0) {
+		if (composite) {
+			r = engine_remove_composite_observer(msg, msg->token, msg->tkl,
+							     accept);
+		} else {
+			r = engine_remove_observer_by_token(msg->ctx, msg->token, msg->tkl);
+			if (r < 0) {
 #if defined(CONFIG_LWM2M_CANCEL_OBSERVE_BY_PATH)
-			r = engine_remove_observer_by_path(msg->ctx, &msg->path);
-			if (r < 0)
+				r = engine_remove_observer_by_path(msg->ctx, &msg->path);
+				if (r < 0)
 #endif /* CONFIG_LWM2M_CANCEL_OBSERVE_BY_PATH */
-			{
-				LOG_ERR("remove observe error: %d", r);
-				r = 0;
+				{
+					LOG_ERR("remove observe error: %d", r);
+					r = 0;
+				}
 			}
 		}
+
 	} else {
 		r = -EINVAL;
 	}
@@ -4479,7 +4815,8 @@ static int handle_request(struct coap_packet *request,
 
 				if ((code & COAP_REQUEST_MASK) == COAP_METHOD_GET) {
 					/* Normal Obeservation Request or Cancel */
-					r = lwm2m_engine_observation_handler(msg, observe, accept);
+					r = lwm2m_engine_observation_handler(msg, observe, accept,
+									     false);
 					if (r < 0) {
 						goto error;
 					}
@@ -4488,8 +4825,12 @@ static int handle_request(struct coap_packet *request,
 				} else {
 					/* Composite Observation request & cancel handler */
 					/* TODO add support for Composite observation support */
-					r = -ENOTSUP;
-					goto error;
+					r = lwm2m_engine_observation_handler(msg, observe, accept,
+									     true);
+					if (r < 0) {
+						goto error;
+					}
+					r = do_composite_read_op(msg, accept);
 				}
 			} else {
 				if ((code & COAP_REQUEST_MASK) == COAP_METHOD_GET) {
@@ -4866,7 +5207,8 @@ static int notify_message_reply_cb(const struct coap_packet *response,
 		if (found_obj) {
 			if (msg->ctx->observe_cb) {
 				msg->ctx->observe_cb(LWM2M_OBSERVE_EVENT_NOTIFY_ACK,
-						     &obs->path, reply->user_data);
+						     lwm2m_read_first_path_ptr(&obs->path_list),
+						     reply->user_data);
 			}
 		}
 	}
@@ -4880,6 +5222,7 @@ static int generate_notify_message(struct lwm2m_ctx *ctx,
 {
 	struct lwm2m_message *msg;
 	struct lwm2m_engine_obj_inst *obj_inst;
+	struct lwm2m_obj_path *path;
 	int ret = 0;
 
 	msg = lwm2m_get_message(ctx);
@@ -4888,30 +5231,40 @@ static int generate_notify_message(struct lwm2m_ctx *ctx,
 		return -ENOMEM;
 	}
 
-	/* copy path */
-	memcpy(&msg->path, &obs->path, sizeof(struct lwm2m_obj_path));
-	msg->operation = LWM2M_OP_READ;
 
-	LOG_DBG("[%s] NOTIFY MSG START: %u/%u/%u(%u) token:'%s' [%s] %lld",
+	if (!obs->composite) {
+		path = lwm2m_read_first_path_ptr(&obs->path_list);
+		if (!path) {
+			LOG_ERR("Observation node not include path");
+			ret = -EINVAL;
+		}
+		/* copy path */
+		memcpy(&msg->path, path, sizeof(struct lwm2m_obj_path));
+		LOG_DBG("[%s] NOTIFY MSG START: %u/%u/%u(%u) token:'%s' [%s] %lld",
+			obs->resource_update ? "MANUAL" : "AUTO", path->obj_id, path->obj_inst_id,
+			path->res_id, path->level, log_strdup(sprint_token(obs->token, obs->tkl)),
+			log_strdup(lwm2m_sprint_ip_addr(&ctx->remote_addr)),
+			(long long)k_uptime_get());
+
+		obj_inst = get_engine_obj_inst(path->obj_id, path->obj_inst_id);
+		if (!obj_inst) {
+			LOG_ERR("unable to get engine obj for %u/%u", path->obj_id,
+				path->obj_inst_id);
+			ret = -EINVAL;
+			goto cleanup;
+		}
+	} else {
+		LOG_DBG("[%s] NOTIFY MSG START: (Composite)) token:'%s' [%s] %lld",
 		obs->resource_update ? "MANUAL" : "AUTO",
-		obs->path.obj_id,
-		obs->path.obj_inst_id,
-		obs->path.res_id,
-		obs->path.level,
 		log_strdup(sprint_token(obs->token, obs->tkl)),
 		log_strdup(lwm2m_sprint_ip_addr(&ctx->remote_addr)),
 		(long long)k_uptime_get());
+	}
+
+	msg->operation = LWM2M_OP_READ;
 
 	obs->resource_update = false;
-	obj_inst = get_engine_obj_inst(obs->path.obj_id,
-				       obs->path.obj_inst_id);
-	if (!obj_inst) {
-		LOG_ERR("unable to get engine obj for %u/%u",
-			obs->path.obj_id,
-			obs->path.obj_inst_id);
-		ret = -EINVAL;
-		goto cleanup;
-	}
+
 
 	msg->type = COAP_TYPE_CON;
 	msg->code = COAP_RESPONSE_CODE_CONTENT;
@@ -4942,8 +5295,13 @@ static int generate_notify_message(struct lwm2m_ctx *ctx,
 
 	/* set the output writer */
 	select_writer(&msg->out, obs->format);
+	if (obs->composite) {
+		/* Use do send which actually do Composite read operation */
+		ret = do_send_op(msg, obs->format, &obs->path_list);
+	} else {
+		ret = do_read_op(msg, obs->format);
+	}
 
-	ret = do_read_op(msg, obs->format);
 	if (ret < 0) {
 		LOG_ERR("error in multi-format read (err:%d)", ret);
 		goto cleanup;
@@ -5130,7 +5488,7 @@ static int64_t engine_observe_shedule_next_event(struct observe_node * obs, uint
 	int64_t t_s = 0;
 	int ret;
 
-	ret = engine_observe_get_attributes(&obs->path, &attrs, srv_obj_inst);
+	ret = engine_observe_attribute_list_get(&obs->path_list, &attrs, srv_obj_inst);
 	if (ret < 0) {
 		return 0;
 	}
@@ -5566,6 +5924,12 @@ int lwm2m_engine_start(struct lwm2m_ctx *client_ctx)
 
 static int lwm2m_engine_init(const struct device *dev)
 {
+	int i;
+
+	for (i = 0; i < LWM2M_ENGINE_MAX_OBSERVER_PATH; i++) {
+		sys_slist_append(&obs_obj_path_list, &observe_paths[i].node);
+	}
+
 	(void)memset(block1_contexts, 0, sizeof(block1_contexts));
 
 	/* start sock receive thread */
@@ -5615,6 +5979,14 @@ static bool lwm2m_path_object_compare(struct lwm2m_obj_path *path,
 		return false;
 	}
 	return true;
+}
+
+static struct lwm2m_obj_path *lwm2m_read_first_path_ptr(sys_slist_t *lwm2m_path_list)
+{
+	struct lwm2m_obj_path_list *entry;
+
+	entry = (struct lwm2m_obj_path_list *)sys_slist_peek_head(lwm2m_path_list);
+	return &entry->path;
 }
 
 void lwm2m_engine_path_list_init(sys_slist_t *lwm2m_path_list, sys_slist_t *lwm2m_free_list,
@@ -5791,7 +6163,7 @@ static int lwm2m_perform_composite_read_root(struct lwm2m_message *msg, uint8_t 
 }
 
 int lwm2m_perform_composite_read_op(struct lwm2m_message *msg, uint16_t content_format,
-				    sys_slist_t *lwm_path_list)
+				    sys_slist_t *lwm2m_path_list)
 {
 	struct lwm2m_engine_obj_inst *obj_inst = NULL;
 	struct lwm2m_obj_path_list *entry;
@@ -5815,7 +6187,7 @@ int lwm2m_perform_composite_read_op(struct lwm2m_message *msg, uint16_t content_
 	engine_put_begin(&msg->out, &msg->path);
 
 	/* Read resource from path */
-	SYS_SLIST_FOR_EACH_CONTAINER(lwm_path_list, entry, node) {
+	SYS_SLIST_FOR_EACH_CONTAINER(lwm2m_path_list, entry, node) {
 		/* Copy path to message path */
 		memcpy(&msg->path, &entry->path, sizeof(struct lwm2m_obj_path));
 
@@ -5857,12 +6229,12 @@ int lwm2m_perform_composite_read_op(struct lwm2m_message *msg, uint16_t content_
 }
 
 static int do_send_op(struct lwm2m_message *msg, uint16_t content_format,
-		      sys_slist_t *lwm_path_list)
+		      sys_slist_t *lwm2m_path_list)
 {
 	switch (content_format) {
 #if defined(CONFIG_LWM2M_RW_SENML_JSON_SUPPORT)
 	case LWM2M_FORMAT_APP_SEML_JSON:
-		return do_send_op_senml_json(msg, lwm_path_list);
+		return do_send_op_senml_json(msg, lwm2m_path_list);
 #endif
 
 	default:
@@ -5909,11 +6281,11 @@ int lwm2m_engine_send(struct lwm2m_ctx *ctx, char const *path_list[], uint8_t pa
 	/* Path list buffer */
 	struct lwm2m_obj_path temp;
 	struct lwm2m_obj_path_list lwm2m_path_list_buf[CONFIG_LWM2M_COMPOSITE_PATH_LIST_SIZE];
-	sys_slist_t lwm_path_list;
-	sys_slist_t lwm_path_free_list;
+	sys_slist_t lwm2m_path_list;
+	sys_slist_t lwm2m_path_free_list;
 
 	/* Init list */
-	lwm2m_engine_path_list_init(&lwm_path_list, &lwm_path_free_list, lwm2m_path_list_buf,
+	lwm2m_engine_path_list_init(&lwm2m_path_list, &lwm2m_path_free_list, lwm2m_path_list_buf,
 				    CONFIG_LWM2M_COMPOSITE_PATH_LIST_SIZE);
 
 	if (path_list_size > CONFIG_LWM2M_COMPOSITE_PATH_LIST_SIZE) {
@@ -5935,12 +6307,12 @@ int lwm2m_engine_send(struct lwm2m_ctx *ctx, char const *path_list[], uint8_t pa
 			return ret;
 		}
 		/* Add to linked list */
-		if (lwm2m_engine_add_path_to_list(&lwm_path_list, &lwm_path_free_list, &temp)) {
+		if (lwm2m_engine_add_path_to_list(&lwm2m_path_list, &lwm2m_path_free_list, &temp)) {
 			return -1;
 		}
 	}
 	/* Clear path which are part are part of recursive path /1 will include /1/0/1 */
-	lwm2m_engine_clear_duplicate_path(&lwm_path_list, &lwm_path_free_list);
+	lwm2m_engine_clear_duplicate_path(&lwm2m_path_list, &lwm2m_path_free_list);
 
 	/* Allocate Message buffer */
 	msg = lwm2m_get_message(ctx);
@@ -5982,7 +6354,7 @@ int lwm2m_engine_send(struct lwm2m_ctx *ctx, char const *path_list[], uint8_t pa
 	}
 
 	/* Write requested path data */
-	ret = do_send_op(msg, content_format, &lwm_path_list);
+	ret = do_send_op(msg, content_format, &lwm2m_path_list);
 	if (ret < 0) {
 		LOG_ERR("Send (err:%d)", ret);
 		goto cleanup;

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -131,7 +131,10 @@ int lwm2m_register_payload_handler(struct lwm2m_message *msg);
 int lwm2m_perform_read_op(struct lwm2m_message *msg, uint16_t content_format);
 
 int lwm2m_perform_composite_read_op(struct lwm2m_message *msg, uint16_t content_format,
-				    sys_slist_t *lwm_path_list);
+				    sys_slist_t *lwm2m_path_list);
+
+int lwm2m_perform_composite_observation_op(struct lwm2m_message *msg, uint8_t *token,
+					   uint8_t token_length, sys_slist_t *lwm2m_path_list);
 
 int lwm2m_write_handler(struct lwm2m_engine_obj_inst *obj_inst,
 			struct lwm2m_engine_res *res,

--- a/subsys/net/lib/lwm2m/lwm2m_rw_senml_json.h
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_senml_json.h
@@ -20,8 +20,12 @@ int do_read_op_senml_json(struct lwm2m_message *msg);
 int do_write_op_senml_json(struct lwm2m_message *msg);
 
 /* Send opearation builder */
-int do_send_op_senml_json(struct lwm2m_message *msg, sys_slist_t *lwm_path_list);
+int do_send_op_senml_json(struct lwm2m_message *msg, sys_slist_t *lwm2m_path_list);
 /* API for call composite READ from engine */
 int do_composite_read_op_senml_json(struct lwm2m_message *msg);
+/* API for call composite READ path list from engine */
+int do_composite_observe_parse_path_senml_json(struct lwm2m_message *msg,
+					       sys_slist_t *lwm2m_path_list,
+					       sys_slist_t *lwm2m_path_free_list);
 
 #endif /* LWM2M_RW_SENML_JSON_H_ */


### PR DESCRIPTION
Composite Observation support:

- Added support for Composite observation for LwM2M v1.1.
- Updated current Observation node to support linked path list.

Observation pmin and pmax refactor:

- Removed to store pmin and pmax at observation node structure and use attribute list store for calculate time for next Notification.
- Obersvation class use timestamp for triggering notification based on resource update which use pmin and default pmax behavior.

Refactor function parameter naming from lwm_ to lwm2m_