### PR TITLE
net: lwm2m: Fix SenML Json Name parser

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rw_senml_json.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_senml_json.c
@@ -1327,8 +1327,8 @@ int do_write_op_senml_json(struct lwm2m_message *msg)
 	struct json_in_formatter_data fd;
 	int ret = 0;
 	uint8_t name[MAX_RESOURCE_LEN + 1];
-	uint8_t base_name[MAX_RESOURCE_LEN + 1];
-	uint8_t full_name[MAX_RESOURCE_LEN + 1];
+	uint8_t base_name[MAX_RESOURCE_LEN + 1] = {0};
+	uint8_t full_name[MAX_RESOURCE_LEN + 1] = {0};
 	struct lwm2m_obj_path resource_path;
 	bool path_valid = false;
 	bool data_value = false;
@@ -1537,8 +1537,8 @@ static uint8_t json_parse_composite_read_paths(struct lwm2m_message *msg,
 	bool path_valid;
 	int ret;
 	uint8_t name[MAX_RESOURCE_LEN];
-	uint8_t base_name[MAX_RESOURCE_LEN];
-	uint8_t full_name[MAX_RESOURCE_LEN];
+	uint8_t base_name[MAX_RESOURCE_LEN + 1] = {0};
+	uint8_t full_name[MAX_RESOURCE_LEN + 1] = {0};
 	uint8_t valid_path_cnt = 0;
 
 	while (json_next_token(&msg->in, &fd)) {


### PR DESCRIPTION
Bug fix for case when base name is not included at message.

Signed-off-by: Juha Heiskanen <juha.heiskanen@nordicsemi.no>