### PR TITLE
net: lwm2m: Disbale SenML CBOR

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -29,7 +29,6 @@ config LWM2M_VERSION_1_0
 config LWM2M_VERSION_1_1
 	bool "LwM2M version 1.1 [EXPERIMENTAL]"
 	select EXPERIMENTAL
-	imply LWM2M_RW_SENML_CBOR_SUPPORT
 
 endchoice
 


### PR DESCRIPTION
Disable default SenML CBOR enable for lwm2m v1.1.

Signed-off-by: Juha Heiskanen <juha.heiskanen@nordicsemi.no>