### PR TITLE
LwM2M ct in registration message

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rw_link_format.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_link_format.c
@@ -28,10 +28,13 @@ LOG_MODULE_REGISTER(net_lwm2m_link_format, CONFIG_LWM2M_LOG_LEVEL);
  * missing.
  */
 
-#if defined(CONFIG_LWM2M_RW_JSON_SUPPORT)
-#define RESOURCE_TYPE		";rt=\"oma.lwm2m\""
 
-#define REG_PREFACE		"</>" RESOURCE_TYPE \
+#if defined(CONFIG_LWM2M_RW_SENML_CBOR_SUPPORT)
+#define REG_PREFACE		"</>;ct=" STRINGIFY(LWM2M_FORMAT_APP_SENML_CBOR)
+#elif defined(CONFIG_LWM2M_SENML_SENML_JSON_SUPPORT)
+#define REG_PREFACE		"</>;ct=" STRINGIFY(LWM2M_FORMAT_APP_SEML_JSON)
+#elif defined(CONFIG_LWM2M_RW_JSON_SUPPORT)
+#define REG_PREFACE		"</>;rt=\"oma.lwm2m\"" \
 				";ct=" STRINGIFY(LWM2M_FORMAT_OMA_JSON)
 #else
 #define REG_PREFACE		""
@@ -61,8 +64,8 @@ static int put_begin(struct lwm2m_output_context *out,
 		break;
 
 	case LINK_FORMAT_MODE_REGISTER:
-		/* Only indicate content type if json is enabled.  */
-		if (!IS_ENABLED(CONFIG_LWM2M_RW_JSON_SUPPORT)) {
+		/* No need to append content type */
+		if (strlen(REG_PREFACE) == 0) {
 			return 0;
 		}
 


### PR DESCRIPTION
Tells the server which content format is preferred in a registration message.

Signed-off-by: Veijo Pesonen <veijo.pesonen@nordicsemi.no>

![image](https://user-images.githubusercontent.com/33285290/163193710-7e259783-8dc3-4c48-b2d1-5954fe027edc.png)
