### PR TITLE
Confirmable message timeout and trigger update

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -92,6 +92,7 @@ struct observe_node {
 	uint8_t  tkl;
 	bool resource_update : 1;	/* Resource is updated */
 	bool composite : 1;		/* Composite Observation */
+	bool active_tx_operation : 1;	/* Active Notification  process ongoing */
 };
 
 struct notification_attrs {
@@ -688,6 +689,7 @@ static void engine_observe_node_init(struct observe_node *obs, const uint8_t *to
 		obs->event_timestamp = 0;
 	}
 	obs->resource_update = false;
+	obs->active_tx_operation = false;
 	obs->format = format;
 	obs->counter = OBSERVE_COUNTER_START;
 	sys_slist_append(&ctx->observer,
@@ -5202,11 +5204,21 @@ static int32_t retransmit_request(struct lwm2m_ctx *client_ctx,
 static void notify_message_timeout_cb(struct lwm2m_message *msg)
 {
 	if (msg->ctx != NULL) {
+		struct observe_node *obs;
 		struct lwm2m_ctx *client_ctx = msg->ctx;
+		sys_snode_t *prev_node = NULL;
 
-		if (client_ctx->observe_cb) {
-			client_ctx->observe_cb(LWM2M_OBSERVE_EVENT_NOTIFY_TIMEOUT,
-					       &msg->path, msg->reply->user_data);
+		obs = engine_observe_node_discover(&client_ctx->observer, &prev_node, NULL,
+						   msg->token, msg->tkl);
+
+		if (obs) {
+			obs->active_tx_operation = false;
+			if (client_ctx->observe_cb) {
+				client_ctx->observe_cb(LWM2M_OBSERVE_EVENT_NOTIFY_TIMEOUT,
+						       &msg->path, msg->reply->user_data);
+			}
+
+			lwm2m_rd_client_timeout(client_ctx);
 		}
 	}
 
@@ -5220,7 +5232,8 @@ static int notify_message_reply_cb(const struct coap_packet *response,
 	int ret = 0;
 	uint8_t type, code;
 	struct lwm2m_message *msg;
-	struct observe_node *obs, *found_obj = NULL;
+	struct observe_node *obs;
+	sys_snode_t *prev_node = NULL;
 
 	type = coap_header_get_type(response);
 	code = coap_header_get_code(response);
@@ -5244,14 +5257,11 @@ static int notify_message_reply_cb(const struct coap_packet *response,
 			LOG_ERR("notify reply missing token -- ignored.");
 		}
 	} else {
-		SYS_SLIST_FOR_EACH_CONTAINER(&msg->ctx->observer, obs, node) {
-			if (memcmp(obs->token, reply->token, reply->tkl) == 0) {
-				found_obj = obs;
-				break;
-			}
-		}
+		obs = engine_observe_node_discover(&msg->ctx->observer, &prev_node, NULL,
+						   reply->token, reply->tkl);
 
-		if (found_obj) {
+		if (obs) {
+			obs->active_tx_operation = false;
 			if (msg->ctx->observe_cb) {
 				msg->ctx->observe_cb(LWM2M_OBSERVE_EVENT_NOTIFY_ACK,
 						     lwm2m_read_first_path_ptr(&obs->path_list),
@@ -5311,6 +5321,7 @@ static int generate_notify_message(struct lwm2m_ctx *ctx,
 	msg->operation = LWM2M_OP_READ;
 
 	obs->resource_update = false;
+	obs->active_tx_operation = true;
 
 
 	msg->type = COAP_TYPE_CON;
@@ -5603,6 +5614,11 @@ static void check_notifications(struct lwm2m_ctx *ctx,
 		if (!obs->event_timestamp || timestamp < obs->event_timestamp) {
 			continue;
 		}
+		/* Check That There is not pending process and client is registred */
+		if (obs->active_tx_operation || !lwm2m_rd_client_is_registred(ctx)) {
+			continue;
+		}
+
 		rc = generate_notify_message(ctx, obs, NULL);
 		if (rc == -ENOMEM) {
 			/* no memory/messages available, retry later */
@@ -6409,6 +6425,7 @@ static int do_send_reply_cb(const struct coap_packet *response,
 static void do_send_timeout_cb(struct lwm2m_message *msg)
 {
 	LOG_WRN("Send Timeout");
+	lwm2m_rd_client_timeout(msg->ctx);
 
 }
 #endif
@@ -6426,6 +6443,11 @@ int lwm2m_engine_send(struct lwm2m_ctx *ctx, char const *path_list[], uint8_t pa
 	struct lwm2m_obj_path_list lwm2m_path_list_buf[CONFIG_LWM2M_COMPOSITE_PATH_LIST_SIZE];
 	sys_slist_t lwm2m_path_list;
 	sys_slist_t lwm2m_path_free_list;
+
+	/* Validate Connection */
+	if (!lwm2m_rd_client_is_registred(ctx)) {
+		return -EPERM;
+	}
 
 	if (lwm2m_server_get_mute_send(ctx->srv_obj_inst)) {
 		LOG_WRN("Send operation is muted by server");

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -1213,6 +1213,30 @@ int lwm2m_rd_client_connection_resume(struct lwm2m_ctx *client_ctx)
 }
 #endif
 
+int lwm2m_rd_client_timeout(struct lwm2m_ctx *client_ctx)
+{
+	if (client.ctx != client_ctx) {
+		return -EPERM;
+	}
+
+	if (!sm_is_registered()) {
+		return 0;
+	}
+
+	LOG_WRN("Confirmable Timeout -> Re-connect and register");
+	client.engine_state = ENGINE_DO_REGISTRATION;
+	return 0;
+}
+
+bool lwm2m_rd_client_is_registred(struct lwm2m_ctx *client_ctx)
+{
+	if (client.ctx != client_ctx || !sm_is_registered()) {
+		return false;
+	}
+
+	return true;
+}
+
 static int lwm2m_rd_client_init(const struct device *dev)
 {
 	k_mutex_init(&client.mutex);

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.h
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.h
@@ -40,6 +40,9 @@
 
 void engine_trigger_update(bool update_objects);
 int engine_trigger_bootstrap(void);
+
+int lwm2m_rd_client_timeout(struct lwm2m_ctx *client_ctx);
+bool lwm2m_rd_client_is_registred(struct lwm2m_ctx *client_ctx);
 #if defined(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP)
 void engine_bootstrap_finish(void);
 #endif


### PR DESCRIPTION
LwM2M engine is blocking new notification send.
Notification or Send timeout trig Reconnect and registration state.
Send/Notification  message is blockked if client is not connected.

Signed-off-by: Juha Heiskanen <juha.heiskanen@nordicsemi.no>