### PR TITLE
[nrf noup] net: lwm2m: LwM2M RD client start and stop update

### DIFF
--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -1180,8 +1180,11 @@ typedef void (*lwm2m_ctx_event_cb_t)(struct lwm2m_ctx *ctx,
  * @param[in] observe_cb Observe callback function called when an observer was
  *			 added or deleted, and when a notification was acked or
  *			 has timed out
+ *
+ * @return 0 for success, -EINPROGRESS when client is already running
+ *         or negative error codes in case of failure.
  */
-void lwm2m_rd_client_start(struct lwm2m_ctx *client_ctx, const char *ep_name,
+int lwm2m_rd_client_start(struct lwm2m_ctx *client_ctx, const char *ep_name,
 			   uint32_t flags, lwm2m_ctx_event_cb_t event_cb,
 			   lwm2m_observe_cb_t observe_cb);
 
@@ -1197,8 +1200,10 @@ void lwm2m_rd_client_start(struct lwm2m_ctx *client_ctx, const char *ep_name,
  * @param[in] event_cb Client event callback function
  * @param[in] deregister True to deregister the client if registered.
  *                       False to force close the connection.
+ *
+ * @return 0 for success or negative in case of error.
  */
-void lwm2m_rd_client_stop(struct lwm2m_ctx *client_ctx,
+int lwm2m_rd_client_stop(struct lwm2m_ctx *client_ctx,
 			  lwm2m_ctx_event_cb_t event_cb, bool deregister);
 
 /**

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -1126,7 +1126,7 @@ static void lwm2m_rd_client_service(struct k_work *work)
 	k_mutex_unlock(&client.mutex);
 }
 
-void lwm2m_rd_client_start(struct lwm2m_ctx *client_ctx, const char *ep_name,
+int lwm2m_rd_client_start(struct lwm2m_ctx *client_ctx, const char *ep_name,
 			   uint32_t flags, lwm2m_ctx_event_cb_t event_cb,
 			   lwm2m_observe_cb_t observe_cb)
 {
@@ -1138,7 +1138,15 @@ void lwm2m_rd_client_start(struct lwm2m_ctx *client_ctx, const char *ep_name,
 			"CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP.");
 
 		k_mutex_unlock(&client.mutex);
-		return;
+		return -ENOTSUP;
+	}
+
+	/* Check client idle state or socket is still active */
+
+	if (client.ctx && (client.engine_state != ENGINE_IDLE || client.ctx->sock_fd != -1)) {
+		LOG_WRN("Client is already running. state %d ", client.engine_state);
+		k_mutex_unlock(&client.mutex);
+		return -EINPROGRESS;
 	}
 
 	client.ctx = client_ctx;
@@ -1154,14 +1162,20 @@ void lwm2m_rd_client_start(struct lwm2m_ctx *client_ctx, const char *ep_name,
 	LOG_INF("Start LWM2M Client: %s", log_strdup(client.ep_name));
 
 	k_mutex_unlock(&client.mutex);
+	return 0;
 }
 
-void lwm2m_rd_client_stop(struct lwm2m_ctx *client_ctx,
+int lwm2m_rd_client_stop(struct lwm2m_ctx *client_ctx,
 			   lwm2m_ctx_event_cb_t event_cb, bool deregister)
 {
 	k_mutex_lock(&client.mutex, K_FOREVER);
 
-	client.ctx = client_ctx;
+	if (client.ctx != client_ctx) {
+		k_mutex_unlock(&client.mutex);
+		LOG_WRN("Cannot stop. Wrong context");
+		return -EPERM;
+	}
+
 	client.event_cb = event_cb;
 
 	if (sm_is_registered() && deregister) {
@@ -1177,6 +1191,7 @@ void lwm2m_rd_client_stop(struct lwm2m_ctx *client_ctx,
 	while (get_sm_state() != ENGINE_IDLE) {
 		k_sleep(K_MSEC(STATE_MACHINE_UPDATE_INTERVAL_MS / 2));
 	}
+	return 0;
 }
 
 void lwm2m_rd_client_update(void)
@@ -1239,7 +1254,10 @@ bool lwm2m_rd_client_is_registred(struct lwm2m_ctx *client_ctx)
 
 static int lwm2m_rd_client_init(const struct device *dev)
 {
+	client.ctx = NULL;
+	client.engine_state = ENGINE_IDLE;
 	k_mutex_init(&client.mutex);
+
 
 	return lwm2m_engine_add_service(lwm2m_rd_client_service,
 					STATE_MACHINE_UPDATE_INTERVAL_MS);


### PR DESCRIPTION
Added return code for for lwm2m_rd_client_start() & lwm2m_rd_client_stop().
Start function return -EINPROGRESS when start is in progress 0 Success
Stop function return -EPERM when context is unknow  and 0 for success.

Signed-off-by: Juha Heiskanen <juha.heiskanen@nordicsemi.no>